### PR TITLE
Add a module entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "debounce-async",
+  "name": "debounce-async-es",
   "version": "0.0.2",
   "description": "A debounced function that delays invoking  asynchronous functions.",
   "main": "index.js",
+  "module": "src/index.js",
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --compilers js:babel-core/register",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "debounce-async-es",
+  "name": "debounce-async",
   "version": "0.0.2",
   "description": "A debounced function that delays invoking  asynchronous functions.",
   "main": "index.js",


### PR DESCRIPTION
For bundlers using native ES, we do not need to use the transpiled `dist`. Expose the untranspiled source as a `module`.

This will also close #2 when using webpack/rollup/parcel